### PR TITLE
fix: preview 相对路径 + 统一 PushFile Admin

### DIFF
--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="zh-CN"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
-<title>Photo Admin</title>
-<link rel="stylesheet" href="{{ base }}/static/admin/style.css">
+<title>PushFile Admin</title>
+<link rel="stylesheet" href="static/admin/style.css">
 </head><body>
 <div class="page">
   <div class="nav">
-    <h1>Photo Admin</h1>
+    <h1>PushFile Admin</h1>
     <span class="badge" id="connBadge">未连接</span>
   </div>
 
@@ -103,9 +103,10 @@
 <div class="toast" id="toast"></div>
 
 <script>
-window.__BASE__ = '{{ base }}';
+// Use relative URLs so preview/prod work without BASE_PATH/proxy special-casing
+window.__BASE__ = '.';
 window.__DOMAIN__ = '{{ domain }}';
 window.__MAX_MB__ = {{ max_mb }};
 </script>
-<script src="{{ base }}/static/admin/app.js"></script>
+<script src="static/admin/app.js"></script>
 </body></html>

--- a/frontend/album/app.js
+++ b/frontend/album/app.js
@@ -28,7 +28,7 @@ function navLb(d, e) {
 }
 
 function updLb() {
-  document.getElementById('lbImg').src = '/d/' + token + '/' + files[lbIdx];
+  document.getElementById('lbImg').src = '../d/' + token + '/' + files[lbIdx];
   document.getElementById('lbInfo').textContent = (lbIdx + 1) + ' / ' + files.length + '  ·  ' + files[lbIdx];
 }
 
@@ -73,7 +73,7 @@ async function downloadAll(e) {
       showOv();
       for (let i = 0; i < files.length; i++) {
         setP(i, files.length, files[i]);
-        const r = await fetch('/d/' + token + '/' + files[i]);
+        const r = await fetch('../d/' + token + '/' + files[i]);
         if (!r.ok) continue;
         const fh = await dir.getFileHandle(files[i], {create: true});
         const ws = await fh.createWritable();
@@ -97,7 +97,7 @@ async function downloadAll(e) {
   showOv();
   for (let i = 0; i < files.length; i++) {
     setP(i, files.length, files[i]);
-    trigger('/f/' + token + '/' + files[i], files[i]);
+    trigger('../f/' + token + '/' + files[i], files[i]);
     await new Promise(r => setTimeout(r, 350));
     setP(i + 1, files.length, files[i]);
   }

--- a/frontend/album/index.html
+++ b/frontend/album/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>{{ title }}</title>
-<link rel="stylesheet" href="{{ base }}/static/album/style.css">
+<link rel="stylesheet" href="../static/album/style.css">
 </head>
 <body>
 <div class="page">
@@ -55,6 +55,6 @@ window.albumFiles = {{ files_json|safe }};
 window.albumToken = '{{ token }}';
 window.albumDomain = '{{ domain }}';
 </script>
-<script src="{{ base }}/static/album/app.js"></script>
+<script src="../static/album/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- 前端静态资源改为相对路径，避免依赖 BASE_PATH/Caddy 特殊配置
- admin 页面 title 和 h1 统一为 PushFile Admin
- album 下载/图片路径改为相对路径，兼容 /preview/{n}/...