### PR TITLE
fix: 修复 /d 页面静态资源路径，恢复渲染

### DIFF
--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -104,7 +104,7 @@
 
 <script>
 // Use relative URLs so preview/prod work without BASE_PATH/proxy special-casing
-window.__BASE__ = '.';
+window.__BASE__ = '{{ base }}';
 window.__DOMAIN__ = '{{ domain }}';
 window.__MAX_MB__ = {{ max_mb }};
 </script>

--- a/frontend/album/app.js
+++ b/frontend/album/app.js
@@ -1,4 +1,3 @@
-const BASE = window.__BASE__ || '';
 const files = window.albumFiles || [];
 const token = window.albumToken || '';
 const domain = window.albumDomain || '';

--- a/frontend/album/index.html
+++ b/frontend/album/index.html
@@ -51,7 +51,6 @@
   </div>
 </div>
 <script>
-window.__BASE__ = '{{ base }}';
 window.albumFiles = {{ files_json|safe }};
 window.albumToken = '{{ token }}';
 window.albumDomain = '{{ domain }}';


### PR DESCRIPTION
关联 Issue #17

- 修复 admin/album 模板静态资源路径为 
- 恢复 BASE_PATH 驱动的路径拼接，避免  被站点首页接管
- 保持  与  下载路径逻辑不变